### PR TITLE
Fix :: focus 에러 헤결

### DIFF
--- a/src/applications/components/taskBar/index.tsx
+++ b/src/applications/components/taskBar/index.tsx
@@ -1,20 +1,20 @@
 import React from "react";
 import * as _ from './style';
-import {useProcessManager} from "@/hooks/processManager";
+import { useProcessManager } from "@/hooks/processManager";
 
 
 interface TaskBarProps {
     startOption: boolean;
     setStartOption: React.Dispatch<React.SetStateAction<boolean>>;
-    focus : string;
+    focus: string;
     setFocus: React.Dispatch<React.SetStateAction<string>>;
     backUpFocus: string;
     setBackUpFocus: React.Dispatch<React.SetStateAction<string>>;
-    setTabDownInterrupt : React.Dispatch<React.SetStateAction<string>>;
+    setTabDownInterrupt: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const TaskBar = ({startOption, setStartOption, focus, setFocus, backUpFocus, setBackUpFocus, setTabDownInterrupt }:TaskBarProps) => {
-    const [taskList,,] = useProcessManager();
+const TaskBar = ({ startOption, setStartOption, focus, setFocus, backUpFocus, setBackUpFocus, setTabDownInterrupt }: TaskBarProps) => {
+    const [taskList, ,] = useProcessManager();
     const taskStyle = { margin: "0.25rem" };
     const taskButtonStyle = {
         height: "100%",
@@ -34,17 +34,18 @@ const TaskBar = ({startOption, setStartOption, focus, setFocus, backUpFocus, set
                             return (
                                 <li style={taskStyle} key={"Observer"}>
                                     <button style={startOption ? taskSelectButtonStyle : taskButtonStyle} //스타트 옵션은 프롭스로
-                                            onClick={(e) => {
-                                                e.stopPropagation();
-                                                setStartOption(!startOption);
-                                                if (startOption) {
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            setStartOption((prev) => {
+                                                if (prev) {
                                                     setFocus(backUpFocus);
                                                 } else {
                                                     setBackUpFocus(focus);
                                                     setFocus("Observer");
                                                 }
-                                            }
-                                            }>Start</button>
+                                                return !prev;
+                                            });
+                                        }}>Start</button>
                                 </li>
                             )
                         } else {

--- a/src/applications/components/taskBar/index.tsx
+++ b/src/applications/components/taskBar/index.tsx
@@ -34,7 +34,8 @@ const TaskBar = ({startOption, setStartOption, focus, setFocus, backUpFocus, set
                             return (
                                 <li style={taskStyle} key={"Observer"}>
                                     <button style={startOption ? taskSelectButtonStyle : taskButtonStyle} //스타트 옵션은 프롭스로
-                                            onClick={() => {
+                                            onClick={(e) => {
+                                                e.stopPropagation();
                                                 setStartOption(!startOption);
                                                 if (startOption) {
                                                     setFocus(backUpFocus);
@@ -58,7 +59,8 @@ const TaskBar = ({startOption, setStartOption, focus, setFocus, backUpFocus, set
                             } else {
                                 return (
                                     <li style={taskStyle} key={task.name}>
-                                        <button style={taskButtonStyle} onClick={() => {
+                                        <button style={taskButtonStyle} onClick={(e) => {
+                                            e.stopPropagation();
                                             setFocus(task.name);
                                         }}>{task.name}</button>
                                     </li>

--- a/src/applications/components/taskBar/index.tsx
+++ b/src/applications/components/taskBar/index.tsx
@@ -1,21 +1,21 @@
 import React from "react";
 import * as _ from './style';
 import { useProcessManager } from "@/hooks/processManager";
+import { useAtom } from "jotai";
+import { focusAtom } from "@/atoms/windowManager";
 
 
 interface TaskBarProps {
     startOption: boolean;
     setStartOption: React.Dispatch<React.SetStateAction<boolean>>;
-    focus: string;
-    setFocus: React.Dispatch<React.SetStateAction<string>>;
     backUpFocus: string;
     setBackUpFocus: React.Dispatch<React.SetStateAction<string>>;
-    setTabDownInterrupt: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const TaskBar = ({ startOption, setStartOption, focus, setFocus, backUpFocus, setBackUpFocus, setTabDownInterrupt }: TaskBarProps) => {
+const TaskBar = ({ startOption, setStartOption, backUpFocus, setBackUpFocus }: TaskBarProps) => {
     const [taskList, ,] = useProcessManager();
     const taskStyle = { margin: "0.25rem" };
+    const [focus, setFocus] = useAtom(focusAtom);
     const taskButtonStyle = {
         height: "100%",
         backgroundColor: "lightgreen"
@@ -53,7 +53,7 @@ const TaskBar = ({ startOption, setStartOption, focus, setFocus, backUpFocus, se
                                 return (
                                     <li style={taskStyle} key={task.name}>
                                         <button style={taskSelectButtonStyle} onClick={() => {
-                                            setTabDownInterrupt(task.name);
+                                            // setTabDownInterrupt(task.name);
                                         }}>{task.name}</button>
                                     </li>
                                 )
@@ -63,6 +63,7 @@ const TaskBar = ({ startOption, setStartOption, focus, setFocus, backUpFocus, se
                                         <button style={taskButtonStyle} onClick={(e) => {
                                             e.stopPropagation();
                                             setFocus(task.name);
+                                            console.log(focus);
                                         }}>{task.name}</button>
                                     </li>
                                 )

--- a/src/applications/discover.tsx
+++ b/src/applications/discover.tsx
@@ -8,13 +8,11 @@ import Seori from "@/applications/seori";
 interface TaskBarProps {
   startOption: boolean;
   setStartOption: React.Dispatch<React.SetStateAction<boolean>>;
-  focus : string;
-  setFocus: React.Dispatch<React.SetStateAction<string>>;
   backUpFocus: string;
   setBackUpFocus: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const Discover = ({startOption, setStartOption, focus, setFocus, backUpFocus, setBackUpFocus }:TaskBarProps) => {
+const Discover = ({startOption, setStartOption, backUpFocus, setBackUpFocus }:TaskBarProps) => {
   const [, addTask, ] = useProcessManager();
   const Apps = useApps();
   return(
@@ -31,7 +29,7 @@ const Discover = ({startOption, setStartOption, focus, setFocus, backUpFocus, se
           </div>
         )
       })}
-      <TaskBar startOption={startOption} setStartOption={setStartOption} focus={focus} setFocus={setFocus} backUpFocus={backUpFocus} setBackUpFocus={setBackUpFocus}/>
+      <TaskBar startOption={startOption} setStartOption={setStartOption} backUpFocus={backUpFocus} setBackUpFocus={setBackUpFocus}/>
     </>
   )
 }

--- a/src/services/windowManager/index.tsx
+++ b/src/services/windowManager/index.tsx
@@ -33,7 +33,7 @@ const WindowManager = () => {
     if (isLogIned) {
       removeTask(logIn)
       const discover: TaskType = {
-        "component": <Discover startOption={startOption} setStartOption={setStartOption} focus={focus} setFocus={setFocus} backUpFocus={backUpFocus} setBackUpFocus={setBackUpFocus} />,
+        "component": <Discover startOption={startOption} setStartOption={setStartOption} backUpFocus={backUpFocus} setBackUpFocus={setBackUpFocus} />,
         "type": "Shell",
         "id": 0,
         "layer": -3,


### PR DESCRIPTION

## 📄 개요
focus로 인해 에러가 나던 사항들을 수정했습니다.

<br>

## 🔨 작업 내용
- 테스크리스트 클릭 시 포커스 변경이 안되던 문제 해결
해결 방법 : 
테스크리스트의 부모 컴포넌트인 discover 클릭 시 포커스가 discover로 바뀌는 로직이 있었는데, 그래서 tasklist를 클릭을 해도 focus가 discover로 덮어쓰기 돼서 바뀌지 않았던 것.
`onClick={() => {onClick={(e) => {e.stopPropagation();` 
이렇게 이벤트 버블링을 막았더니 문제 해결!

- observe 클릭 시 토글로 열고 닫기가 안되던 문제 해결
해결 방법 : 
setStartOption(!startOption) 이후 바로 if (startOption)을 쓰면 옛날 값을 기반으로 분기되기 때문이다.
`setStartOption((prev) => {
                                                if (prev) {
                                                    setFocus(backUpFocus);
                                                } else {
                                                    setBackUpFocus(focus);
                                                    setFocus("Observer");
                                                }
                                                 return !prev;
                                            });
                                        }}>Start</button>
`
이전 상태(prev)를 정확하게 참조하도록 변경

- discover와 taskbar의 focus가 다르던 문제 해결
해결 방법:
이전 코드에서는 jotai를 사용하지만 바보같이 Taskbar로 전역 state인 focus를 프롭스로 넘기고 있었다.. 덤으로 setFocus도 함께 넘겼기 때문에 focus가 discover이랑 taskbar의 focus값이 달라졌다.
props로 넘기던 focus와 setfocus를 지우니 문제가 해결됐다.



https://github.com/user-attachments/assets/cbc9eac5-ff9a-4fc6-8d83-30d7a0eb9291



<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * TaskBar 컴포넌트의 포커스 상태 관리를 전역 상태로 변경하여, 관련 props(focus, setFocus, setTabDownInterrupt)를 제거하고 Jotai 상태를 사용하도록 개선했습니다.
  * Discover 및 WindowManager에서 TaskBar와 Discover 컴포넌트에 전달되는 불필요한 포커스 관련 props를 제거해 인터페이스가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->