### PR TITLE
Fix :: 아이콘과 태스크바 스타일 수정

### DIFF
--- a/src/Theme.css
+++ b/src/Theme.css
@@ -61,7 +61,7 @@ body {
     margin: 0 auto;
     background-image: url('./assets/skeleton.png');
     background-size: cover;
-    gap: 2rem;
+    gap: 0.5rem;
 }
 
 .app-button>button {

--- a/src/applications/components/taskBar/style.ts
+++ b/src/applications/components/taskBar/style.ts
@@ -5,15 +5,16 @@ export const TTaskBar = styled.footer`
     position: absolute;
     bottom: 0;
     width: inherit;
-    height: 3.25rem;
+    height: 2.75rem;
     z-index: 998;
     background-color: var(--light-primary-color);
-    border : 1px black solid;
+    border : 0.063rem black solid;
     display: flex;
-    padding: 8px 20px;
+    padding: 0.25rem 1.25rem;
     flex-direction: column;
+    justify-content: center;
     align-items: flex-start;
-    gap: 10px;
+    gap: 0.625rem;
     box-sizing:border-box;
 `;
 
@@ -24,40 +25,42 @@ export const TaskList = styled.ul`
     width: 100%;
     list-style: none;
     display: flex;
-    gap:6px;
+    gap: 0.375rem;
     align-content: center;
     box-sizing:border-box;
 `;
 
 export const TaskItem = styled.div`
     display: flex;
-    width: 180px;
-    padding: 4px 6px;
+    width: 11.25rem;
+    padding: 0.25rem 0.375rem;
     align-items: center;
-    gap: 6px;
+    gap: 0.375rem;
     height:100%;
     flex-shrink: 0;
-    box-shadow: -1.539px -1.539px 0px 0px var(--secondary-color) inset, 1.539px 1.539px 0px 0px #FFF inset, -3.078px -3.078px 0px 0px #DCAFDD inset;
+    box-shadow: 
+        -0.094rem -0.094rem 0px 0px var(--secondary-color) inset,
+       0.094rem  0.094rem 0px 0px #FFF inset,
+      -0.188rem -0.188rem 0px 0px #DCAFDD inset;
     box-sizing:border-box;
 `
 
 export const ImgContainer = styled.img`
-    width: 24px;
-    height: 24px;
+    width: 1.5rem;
+    height: 1.5rem;
     flex-shrink: 0;
 `
 
 export const TaskName = styled.p`
-    overflow: hidden;
     color: var(--primary-black);
     text-overflow: ellipsis;
     white-space: nowrap;
     font-family: Galmuri11;
-    font-size: 16px;
+    font-size: 1rem;
     font-style: normal;
     font-weight: 400;
-    line-height: 16px;
-    height: 16px;
+    line-height: 1rem;
+    height: 1rem;
 `
 
 export const taskButtonStyle = {
@@ -67,20 +70,24 @@ export const taskButtonStyle = {
 export const taskSelectButtonStyle = {
     height: "100%",
     backgroundColor: "var(--dark-primary-color)",
-    BoxShadow: "-1.5px -1.5px 0px 0px #FFF inset, 1.5px 1.5px 0px 0px var(--primary-black) inset, -3px -3px 0px 0px var(--secondary-color) inset, 3px 3px 0px 0px var(--dark-primary-color) inset"
+    BoxShadow: 
+        "-0.094rem -0.094rem 0px 0px #FFF inset, " +
+        "0.094rem 0.094rem 0px 0px var(--primary-black) inset, " +
+        "-0.188rem -0.188rem 0px 0px var(--secondary-color) inset, " +
+        "0.188rem 0.188rem 0px 0px var(--dark-primary-color) inset"
 }
 
 export const Observer = styled.div<{ selected?: boolean }>`
     display: flex;
-    width: 74px;
-    padding: 4px 12px;
+    width: 4.625rem;
+    padding: 0.25rem 0.75rem;
     justify-content: center;
     align-items: center;
     background: ${({ selected }) =>
         selected ? "var(--dark-primary-color)" : "var(--light-primary-color)"};
-    box-shadow: -1.539px -1.539px 0px 0px var(--secondary-color) inset,
-                1.539px 1.539px 0px 0px #FFF inset,
-                -3.078px -3.078px 0px 0px #DCAFDD inset;
+    box-shadow: -0.094rem -0.094rem 0px 0px var(--secondary-color) inset,
+                0.094rem 0.094rem 0px 0px #FFF inset,
+                -0.188rem -0.188rem 0px 0px #DCAFDD inset;
 `
 
 export const StartImg = styled.img`

--- a/src/applications/discover/style.ts
+++ b/src/applications/discover/style.ts
@@ -1,14 +1,15 @@
+import { getPixelFromPercent } from "@/lib/getPixelFromPercent";
 import styled from "@emotion/styled";
 
 export const AppContainer = styled.div`
     width:100%;
     height:100%;
-    margin-top: 3rem;
-    margin-left: 2rem;
+    margin-top: ${getPixelFromPercent('height', 2)}px;
+    margin-left: ${getPixelFromPercent('height', 2)}px;
 `
 
 export const AppBtn = styled.div<{ url?: string }>`
-    height:75%;
+    height: ${getPixelFromPercent('height', 8)}px;
     aspect-ratio: 1/1;
     margin: 0 auto;
     background-image: url('${({ url }) => url}');
@@ -17,11 +18,11 @@ export const AppBtn = styled.div<{ url?: string }>`
 `
 
 export const AppName = styled.p`
-    margin: 0.5em auto;
+    margin: ${getPixelFromPercent('height', 1)}px auto;
     color: var(--primary-black);
     text-align: center;
     font-family: Galmuri11;
-    font-size: 0.825rem;
+    font-size: 0.9rem;
     font-style: normal;
     font-weight: 400;
     line-height: 18px;


### PR DESCRIPTION
# 개요
아이콘과 태스크바의 스타일을 전부 비율로 바꿨음

---

# 여담
rem쓰니까 개편함 너네도 rem쓰셈

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 그리드 항목 간격이 축소되어 레이아웃이 더 촘촘해졌습니다.
  * TaskBar 및 관련 컴포넌트의 크기, 여백, 그림자 등이 rem 단위로 표준화되고 약간 축소되었습니다.
  * Discover 화면의 버튼, 텍스트, 여백 등이 화면 크기에 따라 반응형으로 조정됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->