### PR TITLE
Fix :: input의 스타일 변경

### DIFF
--- a/src/applications/components/inputs/style.ts
+++ b/src/applications/components/inputs/style.ts
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import '@/assets/font.css';
+import { getPixelFromPercent } from "@/lib/getPixelFromPercent";
 
 export const inputsDiv = styled.div<{fontSize?: string;}>`
     font-family: "Galmuri11";
@@ -11,23 +12,23 @@ export const inputsDiv = styled.div<{fontSize?: string;}>`
     flex-direction: column;
 `;
 export const inputs = styled.input<{width: string;}>`
-    margin: 1.5px 0 0 1.5px;
+    margin: 0.078rem 0 0 0.078rem;
     width: 100%;
     height: 100%;
     font-family: "Galmuri11";
-    padding: 0 0px 0 0;
+    padding: 0 0 0 0;
     outline: none;
     border-color: #DCAFDD;
     border-style: solid;
-    border-width: 2px;
+    border-width: ${getPixelFromPercent("width", 0.125)}px;
     box-sizing: border-box;
 `;
 export const Shadow = styled.div<{width: string;}>`
-    width: ${({ width }) => width || "491px"};
-    height: 28px;
+    width: ${({ width }) => width || "30.688rem"};
+    height: 1.75rem;
     background-color: #000;
-    border-width: 0 1.5px 1.5px 0;
+    border-width: 0 0.078rem 0.078rem 0;
     border-style: solid;
     border-color: #fff;
-    padding: 0.5px 1.5px 1.5px 0.5px;
+    padding: 0.016rem 0.078rem 0.078rem 0.016rem;
 `;


### PR DESCRIPTION
# 개요
input의 스타일의 px을 모두 rem으로 변경하였음
<img width="689" height="173" alt="image" src="https://github.com/user-attachments/assets/f4f1f2fb-5325-4589-bc8b-215565e794c2" />

---

# 여담
Shadow가 다른 컴포넌트보다 좀 두꺼운 감이 있음
나중에 고쳐야됨


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 입력 필드와 그림자 컴포넌트의 스타일 단위를 픽셀에서 rem 단위로 변경하여 일관성을 높였습니다.
  * 입력 필드의 테두리 두께가 동적으로 계산되도록 개선되었습니다.
  * 패딩, 마진 등 일부 스타일 값이 새로운 단위 체계에 맞게 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->