### PR TITLE
Fix :: 모든 hasBooted를 sessionStorage로 옮김

### DIFF
--- a/src/applications/applicationList/myComputer/index.tsx
+++ b/src/applications/applicationList/myComputer/index.tsx
@@ -34,7 +34,7 @@ const MyComputer = () => {
           if (isLoggedIn) {
             localStorage.removeItem('access_token');
             localStorage.setItem('isLogIned', 'false');
-            localStorage.setItem('hasBooted', 'false');
+            sessionStorage.setItem('hasBootedSession', 'false');
             location.reload();
             // logOutMutation.mutate(undefined, {
             //   onSuccess: () => {},

--- a/src/services/kernel.tsx
+++ b/src/services/kernel.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useState } from 'react';
 import Booting from '@/services/booting/index.tsx';
 import WindowManager from './windowManager/index.tsx';
-import { getPixelFromPercent } from '@/lib/getPixelFromPercent.tsx';
+
+const SESSION_KEY = 'hasBootedSession';
 
 function Kernel() {
   const [isBooting, setIsBooting] = useState(() => {
-    return localStorage.getItem('hasBooted') !== 'true';
+    return sessionStorage.getItem(SESSION_KEY) !== 'true';
   });
 
   useEffect(() => {
-    // const px = getPixelFromPercent('width', 1.75);
     const px = 16;
     if (px > 0) {
       document.documentElement.style.fontSize = `${px}px`;
@@ -18,10 +18,11 @@ function Kernel() {
 
   useEffect(() => {
     if (isBooting) {
-      setTimeout(() => {
-        localStorage.setItem('hasBooted', 'true');
+      const id = window.setTimeout(() => {
+        sessionStorage.setItem(SESSION_KEY, 'true'); // 세션 동안만 유지
         setIsBooting(false);
       }, 2700);
+      return () => clearTimeout(id);
     }
   }, [isBooting]);
 


### PR DESCRIPTION
# 개요
hasBooted는 localStorage에 저장되어 있어서 데이터가 영구히 남아있다.
hasBooted는 그런 로직을 기대하고 만든 것이 아니기 때문에 잘못된 방법이라고 할 수 있다.
그래서 나는 hasBooted를 탭 별로 저장되는 sessionStorage에 저장하는 방법을 선택했다.
sessionStorage는 새로고침으로는 데이터가 사라지지 않지만, 탭을 종료하면 데이터가 사라진다.

---

# 여담
isLogined는 왜 localStorage에 있는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - 부팅 상태가 세션 간에 남아 예기치 않게 부팅 화면이 건너뛰어지던 문제를 해소했습니다.
  - 로그아웃 시 현재 세션에서의 부팅 상태가 올바르게 초기화되도록 했습니다.
- 리팩터링
  - 부팅 상태 저장을 영구 저장소에서 세션 단위 저장소로 전환해 세션마다 초기 부팅 경험을 보장했습니다.
  - 글꼴 크기를 16px로 통일해 표시 일관성을 개선했습니다.
  - 부팅 타이머에 정리 로직을 추가해 화면 전환 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->