### PR TITLE
Fix :: Alert 메서드 전부 setAlert으로 변경

### DIFF
--- a/src/api/auth/logIn.ts
+++ b/src/api/auth/logIn.ts
@@ -29,11 +29,11 @@ const logIn = async ({ id, password }: authParams): Promise<string> => {
     return accessToken;
   } catch (error) {
     const axiosError = error as AxiosError;
-    if (axiosError.response?.headers) {
-      alert(`로그인 실패: 다시 입력해 주세요!`);
+    if (axiosError.response && axiosError.response.headers) {
+      // alert(`로그인 실패: 다시 입력해 주세요!`);
       console.log(`로그인 실패: ${JSON.stringify(axiosError.response.headers)}`);
     } else {
-      alert('로그인 중 오류가 발생했습니다.');
+      // alert('로그인 중 오류가 발생했습니다.');
     }
     throw error;
   }

--- a/src/applications/utility/auth/index.tsx
+++ b/src/applications/utility/auth/index.tsx
@@ -1,8 +1,12 @@
 import React, { useRef, useState } from 'react';
 import * as _ from '@/applications/utility/auth/style.ts';
 import Logo from '@/assets/windeath44.svg';
+import Choten from '@/assets/profile/choten.svg';
 import { useChangeKeyValidation } from '@/api/auth/changeKeyValidation.ts';
 import MemorialBtn from '@/applications/components/memorialBtn';
+import { useAtomValue } from 'jotai';
+import { alerterAtom } from '@/atoms/alerter';
+import { taskTransformerAtom } from '@/atoms/taskTransformer';
 interface Props {
   changeToPassword: () => void;
   changeToEmailCheck: () => void;
@@ -12,6 +16,10 @@ const Auth = ({ changeToPassword, changeToEmailCheck }: Props) => {
   const [code, setCode] = useState<string[]>(Array(inputLength).fill(''));
   const inputRefs = useRef<Array<HTMLInputElement | null>>([]);
   const mutationChangeKeyValidation = useChangeKeyValidation();
+
+  const setAlert = useAtomValue(alerterAtom);
+  const taskTransform = useAtomValue(taskTransformerAtom);
+
   const handleChange = (value: string, index: number) => {
     if (!/^[a-zA-Z0-9]?$/.test(value)) return; // 숫자 & 알파벳만 허용
     const newCode = [...code];
@@ -28,6 +36,21 @@ const Auth = ({ changeToPassword, changeToEmailCheck }: Props) => {
     }
   };
   const handleSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (code.length < inputLength) {
+      setAlert?.(
+        Choten,
+        <>
+          인증코드가 잘못되었습니다.
+          <br />
+          다시 입력해 주세요.
+        </>,
+        () => {
+          taskTransform?.('경고', '');
+        },
+      );
+      return;
+    }
+
     e.preventDefault();
     const authorizationCode = code.join('');
     mutationChangeKeyValidation.mutate(
@@ -40,8 +63,8 @@ const Auth = ({ changeToPassword, changeToEmailCheck }: Props) => {
     );
   };
 
-  const buttonWidth = "144px";
-  const buttonHeight = "42px";
+  const buttonWidth = '144px';
+  const buttonHeight = '42px';
   const buttonFontSize = '20px';
 
   return (

--- a/src/applications/utility/emailCheck/index.tsx
+++ b/src/applications/utility/emailCheck/index.tsx
@@ -1,9 +1,13 @@
 import { useState } from 'react';
 import * as _ from '@/applications/utility/emailCheck/style.ts';
 import Logo from '@/assets/windeath44.svg';
+import Choten from '@/assets/profile/choten.svg';
 import Inputs from '@/applications/components/inputs';
 import { useChangeTemporaryKey } from '@/api/auth/changetemporaryKey.ts';
 import MemorialBtn from '@/applications/components/memorialBtn';
+import { useAtomValue } from 'jotai';
+import { alerterAtom } from '@/atoms/alerter';
+import { taskTransformerAtom } from '@/atoms/taskTransformer';
 
 interface Props {
   changeToLogIn: () => void;
@@ -13,7 +17,26 @@ interface Props {
 const EmailChack = ({ changeToLogIn, changeToAuth }: Props) => {
   const [email, setEmail] = useState('');
   const mutationChangeKey = useChangeTemporaryKey();
+
+  const setAlert = useAtomValue(alerterAtom);
+  const taskTransform = useAtomValue(taskTransformerAtom);
+
   const checkEmail = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (email.length === 0) {
+      setAlert?.(
+        Choten,
+        <>
+          이메일이 잘못되었습니다.
+          <br />
+          다시 입력해 주세요.
+        </>,
+        () => {
+          taskTransform?.('경고', '');
+        },
+      );
+      return;
+    }
+
     e.preventDefault();
     mutationChangeKey.mutate(
       { email },
@@ -25,8 +48,8 @@ const EmailChack = ({ changeToLogIn, changeToAuth }: Props) => {
     );
   };
 
-  const buttonWidth = "144px";
-  const buttonHeight = "42px";
+  const buttonWidth = '144px';
+  const buttonHeight = '42px';
   const buttonFontSize = '20px';
 
   return (

--- a/src/applications/utility/login/index.tsx
+++ b/src/applications/utility/login/index.tsx
@@ -81,6 +81,18 @@ const LogIn = ({ changeToSignUp, changeToEmailCheck }: Props) => {
                 },
               );
             }
+          } else {
+            setAlert?.(
+              Choten,
+              <>
+                로그인에 실패했습니다.
+                <br />
+                잠시 후 다시 시도해주세요.
+              </>,
+              () => {
+                taskTransform?.('경고', '');
+              },
+            );
           }
         },
       },

--- a/src/applications/utility/login/index.tsx
+++ b/src/applications/utility/login/index.tsx
@@ -1,5 +1,6 @@
 import * as _ from './style';
 import Logo from '@/assets/windeath44.svg';
+import Choten from '@/assets/profile/choten.svg';
 import Inputs from '@/applications/components/inputs';
 import { useAtom, useAtomValue } from 'jotai';
 import { useEffect, useState } from 'react';
@@ -7,6 +8,8 @@ import { useLogIn } from '@/api/auth/logIn';
 import { taskTransformerAtom } from '@/atoms/taskTransformer';
 import MemorialBtn from '@/applications/components/memorialBtn';
 import { isLogInedAtom } from '@/atoms/windowManager';
+import { alerterAtom } from '@/atoms/alerter';
+import { Axios, AxiosError } from 'axios';
 type Props = {
   changeToSignUp: () => void;
   changeToEmailCheck: () => void;
@@ -17,6 +20,9 @@ const LogIn = ({ changeToSignUp, changeToEmailCheck }: Props) => {
   const logInMutation = useLogIn();
   const taskTransform = useAtomValue(taskTransformerAtom);
   const [isLogIned, setIsLogIned] = useAtom(isLogInedAtom);
+
+  const setAlert = useAtomValue(alerterAtom);
+
   const inputList = [
     {
       label: '아이디:',
@@ -48,6 +54,34 @@ const LogIn = ({ changeToSignUp, changeToEmailCheck }: Props) => {
         },
         onError: (error) => {
           console.error('로그인 실패', error);
+          const axiosError = error as AxiosError;
+          if (axiosError.response) {
+            if (axiosError.response.status === 404) {
+              setAlert?.(
+                Choten,
+                <>
+                  로그인에 실패했습니다.
+                  <br />
+                  아이디와 비밀번호를 확인해주세요.
+                </>,
+                () => {
+                  taskTransform?.('경고', '');
+                },
+              );
+            } else {
+              setAlert?.(
+                Choten,
+                <>
+                  로그인에 실패했습니다.
+                  <br />
+                  잠시 후 다시 시도해주세요.
+                </>,
+                () => {
+                  taskTransform?.('경고', '');
+                },
+              );
+            }
+          }
         },
       },
     );
@@ -57,8 +91,8 @@ const LogIn = ({ changeToSignUp, changeToEmailCheck }: Props) => {
     localStorage.setItem('isLogIned', isLogIned);
   }, [isLogIned]);
 
-  const buttonWidth = "144px";
-  const buttonHeight = "42px";
+  const buttonWidth = '144px';
+  const buttonHeight = '42px';
   const buttonFontSize = '20px';
   return (
     <_.tempMain>

--- a/src/applications/utility/login/index.tsx
+++ b/src/applications/utility/login/index.tsx
@@ -9,7 +9,7 @@ import { taskTransformerAtom } from '@/atoms/taskTransformer';
 import MemorialBtn from '@/applications/components/memorialBtn';
 import { isLogInedAtom } from '@/atoms/windowManager';
 import { alerterAtom } from '@/atoms/alerter';
-import { Axios, AxiosError } from 'axios';
+import { AxiosError } from 'axios';
 type Props = {
   changeToSignUp: () => void;
   changeToEmailCheck: () => void;
@@ -44,6 +44,34 @@ const LogIn = ({ changeToSignUp, changeToEmailCheck }: Props) => {
   const checkLogIn = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     const id = userId;
+    if (id.length === 0) {
+      setAlert?.(
+        Choten,
+        <>
+          아이디가 잘못되었습니다.
+          <br />
+          다시 입력해 주세요.
+        </>,
+        () => {
+          taskTransform?.('경고', '');
+        },
+      );
+      return;
+    }
+    if (password.length === 0) {
+      setAlert?.(
+        Choten,
+        <>
+          비밀번호가 잘못되었습니다.
+          <br />
+          다시 입력해 주세요.
+        </>,
+        () => {
+          taskTransform?.('경고', '');
+        },
+      );
+      return;
+    }
     logInMutation.mutate(
       { id, password },
       {

--- a/src/applications/utility/passwordChange/index.tsx
+++ b/src/applications/utility/passwordChange/index.tsx
@@ -1,9 +1,13 @@
 import * as _ from './style';
 import Logo from '@/assets/windeath44.svg';
+import Choten from '@/assets/profile/choten.svg';
 import Inputs from '@/applications/components/inputs';
 import React, { useState } from 'react';
 import { useResetPassword } from '@/api/user/resetUserPassword.ts';
 import MemorialBtn from '@/applications/components/memorialBtn';
+import { useAtomValue } from 'jotai';
+import { alerterAtom } from '@/atoms/alerter';
+import { taskTransformerAtom } from '@/atoms/taskTransformer';
 interface Props {
   changeToLogIn: () => void;
 }
@@ -12,14 +16,38 @@ const PasswordChange = ({ changeToLogIn }: Props) => {
   const [checkingPw, setCheckingPw] = useState<string>('');
   const [email, setEmail] = useState<string>('');
   const mutateResetPassword = useResetPassword();
+
+  const setAlert = useAtomValue(alerterAtom);
+  const taskTransform = useAtomValue(taskTransformerAtom);
+
   const handleSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     if (!email || !password || !checkingPw) {
-      alert('모든 필드를 입력해주세요.');
+      setAlert?.(
+        Choten,
+        <>
+          빈 입력칸이 존재합니다.
+          <br />
+          다시 입력해 주세요.
+        </>,
+        () => {
+          taskTransform?.('경고', '');
+        },
+      );
       return;
     }
     if (password !== checkingPw) {
-      alert('비밀번호가 일치하지 않습니다.');
+      setAlert?.(
+        Choten,
+        <>
+          비밀번호가 일치하지 않습니다.
+          <br />
+          다시 입력해 주세요.
+        </>,
+        () => {
+          taskTransform?.('경고', '');
+        },
+      );
       return;
     }
     mutateResetPassword.mutate(

--- a/src/applications/utility/signUp/index.tsx
+++ b/src/applications/utility/signUp/index.tsx
@@ -31,6 +31,48 @@ const SignUp = ({ changeToLogIn }: Props) => {
   const verifyEmailMutation = useVerifyEmail();
 
   const sendAuth = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (name.length == 0) {
+      setAlert?.(
+        Choten,
+        <>
+          사용자 이름이 잘못되었습니다.
+          <br />
+          다시 입력해 주세요.
+        </>,
+        () => {
+          taskTransform?.('경고', '');
+        },
+      );
+      return;
+    }
+    if (userId.length == 0) {
+      setAlert?.(
+        Choten,
+        <>
+          아이디가 잘못되었습니다.
+          <br />
+          다시 입력해 주세요.
+        </>,
+        () => {
+          taskTransform?.('경고', '');
+        },
+      );
+      return;
+    }
+    if (email.length == 0 || !email.includes('@')) {
+      setAlert?.(
+        Choten,
+        <>
+          이메일이 잘못되었습니다.
+          <br />
+          다시 입력해 주세요.
+        </>,
+        () => {
+          taskTransform?.('경고', '');
+        },
+      );
+      return;
+    }
     if (pw !== checkingPw) {
       setAlert?.(
         Choten,

--- a/src/applications/utility/signUp/index.tsx
+++ b/src/applications/utility/signUp/index.tsx
@@ -1,11 +1,15 @@
 import * as _ from './style';
 import Logo from '@/assets/windeath44.svg';
+import Choten from '@/assets/profile/choten.svg';
 import { useEffect, useState } from 'react';
 import Inputs from '@/applications/components/inputs';
 import { useSignUp } from '@/api/user/signUp.ts';
 import { useEmailValidation } from '@/api/auth/emailValidationRequest.ts';
 import { useVerifyEmail } from '@/api/auth/verifyEmailCode.ts';
 import MemorialBtn from '@/applications/components/memorialBtn';
+import { useAtomValue } from 'jotai';
+import { alerterAtom } from '@/atoms/alerter';
+import { taskTransformerAtom } from '@/atoms/taskTransformer';
 type Props = {
   changeToLogIn: () => void;
 };
@@ -19,17 +23,40 @@ const SignUp = ({ changeToLogIn }: Props) => {
   const [click, setClick] = useState(false);
   const [timeLeft, setTimeLeft] = useState(180);
 
+  const setAlert = useAtomValue(alerterAtom);
+  const taskTransform = useAtomValue(taskTransformerAtom);
+
   const signUpMutation = useSignUp();
   const emailValidationMutation = useEmailValidation();
   const verifyEmailMutation = useVerifyEmail();
 
   const sendAuth = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (pw !== checkingPw) {
-      alert('비밀번호가 일치하지 않습니다.');
+      setAlert?.(
+        Choten,
+        <>
+          비밀번호가 일치하지 않습니다.
+          <br />
+          다시 입력해 주세요.
+        </>,
+        () => {
+          taskTransform?.('경고', '');
+        },
+      );
       return;
     }
     if (pw.length < 8 || pw.length > 20) {
-      alert('비밀번호는 8~20 문자만 허용합니다.\n 다시 입력해 주세요!!');
+      setAlert?.(
+        Choten,
+        <>
+          비밀번호가 8~20자리가 아닙니다.
+          <br />
+          다시 입력해 주세요.
+        </>,
+        () => {
+          taskTransform?.('경고', '');
+        },
+      );
       return;
     }
     signUpMutation.mutate({ name, userId, email, pw, changeToLogIn });
@@ -54,7 +81,9 @@ const SignUp = ({ changeToLogIn }: Props) => {
       verifyEmailMutation.mutate({ email, check });
       setClick(false);
     } else {
-      alert('인증코드 5자리를 입력하지 않았습니다.');
+      setAlert?.(Choten, <>인증코드 5자리를 입력하지 않았습니다.</>, () => {
+        taskTransform?.('경고', '');
+      });
     }
   };
   useEffect(() => {
@@ -76,8 +105,8 @@ const SignUp = ({ changeToLogIn }: Props) => {
     return `${min.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}`;
   };
 
-  const buttonWidth = "144px";
-  const buttonHeight = "42px";
+  const buttonWidth = '144px';
+  const buttonHeight = '42px';
   const buttonFontSize = '20px';
 
   return (
@@ -123,8 +152,8 @@ const SignUp = ({ changeToLogIn }: Props) => {
                 onClick={sendEmail}
                 type="submit"
                 active={true}
-                height='34px'
-                fontSize={"16px"}
+                height="34px"
+                fontSize={'16px'}
               />
             </_.btnSet>
           </_.set>
@@ -143,8 +172,8 @@ const SignUp = ({ changeToLogIn }: Props) => {
                 onClick={verifyCode}
                 type="submit"
                 active={true}
-                height='34px'
-                fontSize={"16px"}
+                height="34px"
+                fontSize={'16px'}
               />
             </_.btnSet>
           </_.set>
@@ -173,8 +202,8 @@ const SignUp = ({ changeToLogIn }: Props) => {
             onClick={sendAuth}
             type="submit"
             active={true}
-            widthPercent={buttonWidth}
-            heightPercent={buttonHeight}
+            width={buttonWidth}
+            height={buttonHeight}
             fontSize={buttonFontSize}
           />
           <MemorialBtn
@@ -182,8 +211,8 @@ const SignUp = ({ changeToLogIn }: Props) => {
             onClick={changeToLogIn}
             type="submit"
             active={true}
-            widthPercent={buttonWidth}
-            heightPercent={buttonHeight}
+            width={buttonWidth}
+            height={buttonHeight}
             fontSize={buttonFontSize}
           />
         </_.tempButtonsStyle>

--- a/src/hooks/taskSearch.tsx
+++ b/src/hooks/taskSearch.tsx
@@ -26,9 +26,13 @@ export const useTaskSearchFunction = () => {
     const internal = original.props.children as React.ReactElement;
     const type = internal.type;
 
+    // 기존 props를 유지하고 새로운 props를 병합
+    const existingProps = internal.props || {};
+
     foundTask.component = (
       <Suspense fallback={null}>
         {React.createElement(type, {
+          ...existingProps,
           ...(props ?? {}),
         })}
       </Suspense>


### PR DESCRIPTION
# 개요
로그인 관련 페이지의 오류들이 전부 alert으로 처리되고 있었는데, 그것을 전부 setAlert으로 변경함
<img width="579" height="264" alt="image" src="https://github.com/user-attachments/assets/7e67935f-084b-4472-802b-1f67ff915519" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 로그인/회원가입/비밀번호 변경/이메일 확인에 인앱 경고창 도입(아이콘 포함) 및 입력값 검증 추가
  - 로그인 실패 시 상황별 메시지 제공(잘못된 자격 증명, 기타 오류, 응답 없음 구분)
- Bug Fixes
  - 컴포넌트 속성 병합 로직 개선으로 일부 UI 동작 누락 가능성 해소
- Style
  - 버튼 크기 및 관련 스타일 표기 방식 일관화로 UI 일치감 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->