### PR TITLE
Fix :: getMemorialTracing 오류 수정

### DIFF
--- a/src/api/memorial/getMemorialTracing.ts
+++ b/src/api/memorial/getMemorialTracing.ts
@@ -23,7 +23,7 @@ const getMemorialTracing = async (
   const response = await axiosInstance.get(`${memorial}/memorial-tracing/${userId}`, {
     params: {
       size,
-      ...(cursor && { cursor: toUnixTime(cursor) })
+      ...(cursor && { cursor }),
     },
   });
   return response.data;

--- a/src/api/memorial/getMemorialTracing.ts
+++ b/src/api/memorial/getMemorialTracing.ts
@@ -2,29 +2,28 @@ import { useQuery } from '@tanstack/react-query';
 import axiosInstance from '../axiosInstance';
 import { memorial } from '@/config';
 
-interface MemorialCommentResponse {
-  commentId: number;
+interface MemorialTracingData {
   memorialId: number;
-  userId: string;
-  content: string;
-  likes: number;
-  isLiked: boolean;
-  parentId: number;
-  createdAt: string;
+  viewedAt: string;
 }
 
 interface MemorialTracingResponse {
   message: string;
-  data: MemorialCommentResponse[];
+  data: {
+    hasNext: boolean;
+    data: MemorialTracingData[];
+  };
 }
 
 const getMemorialTracing = async (
   userId: string,
   size: number = 6,
+  cursor?: string
 ): Promise<MemorialTracingResponse> => {
   const response = await axiosInstance.get(`${memorial}/memorial-tracing/${userId}`, {
     params: {
       size,
+      ...(cursor && { cursor: toUnixTime(cursor) })
     },
   });
   return response.data;

--- a/src/applications/applicationList/myComputer/index.tsx
+++ b/src/applications/applicationList/myComputer/index.tsx
@@ -179,11 +179,11 @@ const MyComputer = () => {
                 <_.MessageText>로딩 중...</_.MessageText>
               ) : tracingError ? (
                 <_.MessageText>데이터를 불러오는 중 오류가 발생했습니다.</_.MessageText>
-              ) : memorialTracingData?.data?.length === 0 ? (
+              ) : memorialTracingData?.data?.data?.length === 0 ? (
                 <_.MessageText>방문한 추모관이 없습니다.</_.MessageText>
               ) : (
                 // memorialId로 고유한 추모관 목록 생성
-                Array.from(new Set(memorialTracingData?.data?.map((comment) => comment.memorialId)))
+                Array.from(new Set(memorialTracingData?.data?.data?.map((comment) => comment.memorialId)))
                   .slice(0, 3) // 최대 3개만 표시
                   .map((memorialId) => (
                     <MemorialItem

--- a/src/lib/toUnixTime.ts
+++ b/src/lib/toUnixTime.ts
@@ -1,0 +1,6 @@
+const toUnixTime = (date: string): number => {
+  const formatted = date.replace("/", "T") + ":00";
+  const unixdate = new Date(formatted);
+  if (isNaN(unixdate.getTime())) throw new Error("Invalid date format");
+  return unixdate.getTime();
+}

--- a/src/lib/toUnixTime.ts
+++ b/src/lib/toUnixTime.ts
@@ -1,7 +1,0 @@
-const toUnixTime = (date: string | undefined): number => {
-  if (date === undefined) throw new Error("date is undefined");
-  const formatted = date.replace("/", "T") + ":00";
-  const unixdate = new Date(formatted);
-  if (isNaN(unixdate.getTime())) throw new Error("Invalid date format");
-  return unixdate.getTime();
-}

--- a/src/lib/toUnixTime.ts
+++ b/src/lib/toUnixTime.ts
@@ -1,4 +1,5 @@
-const toUnixTime = (date: string): number => {
+const toUnixTime = (date: string | undefined): number => {
+  if (date === undefined) throw new Error("date is undefined");
   const formatted = date.replace("/", "T") + ":00";
   const unixdate = new Date(formatted);
   if (isNaN(unixdate.getTime())) throw new Error("Invalid date format");


### PR DESCRIPTION
## getMemorialTracing.ts 훅 수정
### 기존 문제점
1. ```MemorialTracingResponse``` 인터페이스가 API의 반환값과 큰 차이 발생
2. ```getMemorialTracing.ts```의 쿼리파라미터에 cursor 속성이 없음
3. ```MemorialTracingResponse``` 의 하위 interface이름, ```MemorialCommentResponse```가 이 API와 큰 관련성이 없음
### 해결방안
1. ```getMemorialTracing.ts``` 훅의 ```MemorialTracingResponse``` interface를 API 명세서에 맞춰 수정
2. ```getMemorialTracing``을 사용하는 ```myComputer/index.tsx```를 interface에 맞추어 수정
### 테스트
테스트를 위해 로컬환경, windowManager의 isLogIned를 강제로 guest로 고정한 상태로 진입, myComputer의 삼항연산자 조건을 고정함.
더미데이터는 API명세서에 있는 예시 데이터를 활용, ```getMemorialTracing.ts``` 훅에서 바로 return하도록 설정
<img width="1905" height="1486" alt="image" src="https://github.com/user-attachments/assets/603459b2-ecb3-4be1-9f03-53bde3c13b98" />
다음과 같이 동작함을 알 수 있음
### 추후 개선방향
이후로는 개인적인 견해가 담겨있음.
현재 ```myComputer/index.tsx```에서는 데이터 접근을 위해 ```memorialTracingData?.data?.data?``` 와 같이 사용하는 경우가 존재함
검증하는 로직을 분리하여 최종적으로 ```MemorialTracingData[]``` 로 넘겨주는 것이 가독성이 높아보임

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 추모 기록 조회에 커서 기반 페이지네이션을 도입하여 더 많은 항목을 순차적으로 불러올 수 있습니다.
  - 스크롤 시 이어보기 경험이 개선되었습니다.

- 버그 수정
  - 비어 있는 목록 감지 로직을 정교화하여, 항목이 없을 때 올바른 상태가 표시됩니다.
  - 목록 렌더링의 안정성과 일관성을 개선하여 간헐적 표시 오류를 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->