### PR TITLE
Fix :: 검색에서 너무 많은 요청 수정

### DIFF
--- a/src/applications/applicationList/memorialCommit/index.tsx
+++ b/src/applications/applicationList/memorialCommit/index.tsx
@@ -132,6 +132,8 @@ const MemorialCommit = ({
         from={userId}
         content={memorialData?.content || ''}
         isPerson={true}
+        memorialId={memorialData?.memorialId}
+        characterId={characterData?.characterId}
       />
     </_.Container>
   );

--- a/src/applications/applicationList/search/viewer/index.tsx
+++ b/src/applications/applicationList/search/viewer/index.tsx
@@ -42,12 +42,12 @@ const Viewer = ({ characters, memorials, stack, push, pop, top }: ViewerProps) =
                   name={character.name}
                   onDoubleClick={() => {
                     const characterId = character.characterId;
-                    let targetMemorialId = memorialId;
+                    let targetMemorialId = relatedMemorials[0].memorialId;
 
-                    if (relatedMemorials.length > 0) {
-                      targetMemorialId = relatedMemorials[0].memorialId;
-                      setMemorialId(targetMemorialId);
-                    }
+                    // if (relatedMemorials.length > 0) {
+                    //   targetMemorialId = relatedMemorials[0].memorialId;
+                    //   setMemorialId(targetMemorialId);
+                    // }
 
                     taskTransform?.('', '추모관 뷰어', {
                       memorialId: targetMemorialId,

--- a/src/applications/components/memorialTextarea/index.tsx
+++ b/src/applications/components/memorialTextarea/index.tsx
@@ -12,6 +12,8 @@ interface PropsType {
   content: string;
   isReadonly?: boolean;
   isPerson?: boolean;
+  memorialId?: number;
+  characterId?: number;
 }
 
 const MemorialTextarea = ({
@@ -20,6 +22,8 @@ const MemorialTextarea = ({
   content,
   isReadonly = false,
   isPerson = false,
+  memorialId,
+  characterId,
 }: PropsType) => {
   const [contentIn, setContentIn] = useAtom(inputContent);
   // const [isClickOpen, setClickOpen] = useState<boolean>(false);
@@ -54,7 +58,7 @@ const MemorialTextarea = ({
           ></_.CommitArea>
         </_.CommitAreaContainer>
       </_.Container>
-      {isPerson ? <MergeBtn text={btnText} /> : <></>}
+      {isPerson && memorialId ? <MergeBtn text={btnText} memorialId={memorialId} characterId={characterId} /> : <></>}
     </>
   );
 };

--- a/src/applications/components/mergeBtn/index.tsx
+++ b/src/applications/components/mergeBtn/index.tsx
@@ -9,21 +9,22 @@ import { alerterAtom } from '@/atoms/alerter';
 import { useProcessManager } from '@/hooks/processManager';
 import { useAtom, useAtomValue } from 'jotai';
 import { usePostCommit, usePostPullRequest } from '@/api/memorial/userCommit.ts';
-import { memorialIdAtom, userIdAtom, currentStackTopAtom } from '@/atoms/memorialManager.ts';
+import { userIdAtom, currentStackTopAtom } from '@/atoms/memorialManager.ts';
 import { useGetPrsQuery } from '@/api/memorial/cheifCommit.ts';
 
 interface PropsType {
   text: string;
+  memorialId: number;
+  characterId?: number;
 }
 
-const MergeBtn = ({ text }: PropsType) => {
+const MergeBtn = ({ text, memorialId, characterId }: PropsType) => {
   const [inputValue, setInputValue] = useAtom(inputPortage);
   const [contentIn, setContentIn] = useAtom(inputContent);
   const [userId] = useAtom(userIdAtom);
-  const [memorialId] = useAtom(memorialIdAtom);
   const createCharacterMutation = useCreateCharacter();
   const commitMutation = usePostCommit();
-  const { data, isLoading, isError, error } = useGetPrsQuery({ memorialId });
+  const { data } = useGetPrsQuery({ memorialId });
   const pullRequestMutation = usePostPullRequest();
   const uploadImageMutation = useUploadImage();
   const applyMemorialMutation = useApplyMemorial();


### PR DESCRIPTION
# 개요
검색할 때 인풋 값이 바뀔 때 마다 서버에 요청이 가는 문제가 있었음.
지금은 입력이 끝나고 0.5초 후에 요청이 가도록 변경.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 검색 화면에 입력값 디바운스를 적용해 불필요한 재검색을 줄이고 더 안정적인 필터링을 제공합니다.
  - 뷰어에서 더블클릭 시 첫 번째 관련 메모리얼로 바로 이동하도록 동작을 조정했습니다.
- Bug Fixes
  - 메모리얼 ID가 없을 때 병합 버튼이 노출되지 않도록 수정해 잘못된 작업 유도를 방지했습니다.
- Refactor
  - 병합 버튼이 전역 상태 대신 전달받은 식별자(props)로 동작하도록 구조를 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->