### PR TITLE
Fix :: 로그인 UI 변경

### DIFF
--- a/src/applications/utility/login/index.tsx
+++ b/src/applications/utility/login/index.tsx
@@ -76,7 +76,7 @@ const LogIn = ({ changeToSignUp, changeToEmailCheck }: Props) => {
       { id, password },
       {
         onSuccess: (token) => {
-// console.log('로그인 성공 토큰 :', token);
+          // console.log('로그인 성공 토큰 :', token);
           setIsLogIned('true');
           taskTransform?.('LogIn', '');
         },
@@ -155,8 +155,11 @@ const LogIn = ({ changeToSignUp, changeToEmailCheck }: Props) => {
         </_.tempInputs>
         <_.tempButtons>
           <MemorialBtn
-            name="확인"
-            onClick={checkLogIn}
+            name="손님으로 입장"
+            onClick={() => {
+              setIsLogIned('guest');
+              taskTransform?.('LogIn', '');
+            }}
             type="submit"
             width={buttonWidth}
             height={buttonHeight}
@@ -164,11 +167,8 @@ const LogIn = ({ changeToSignUp, changeToEmailCheck }: Props) => {
             active={true}
           />
           <MemorialBtn
-            name="취소"
-            onClick={() => {
-              setIsLogIned('guest');
-              taskTransform?.('LogIn', '');
-            }}
+            name="회원가입"
+            onClick={() => changeToSignUp()}
             type="submit"
             width={buttonWidth}
             height={buttonHeight}
@@ -185,8 +185,8 @@ const LogIn = ({ changeToSignUp, changeToEmailCheck }: Props) => {
             active={true}
           />
           <MemorialBtn
-            name="회원가입"
-            onClick={() => changeToSignUp()}
+            name="로그인"
+            onClick={checkLogIn}
             type="submit"
             width={buttonWidth}
             height={buttonHeight}


### PR DESCRIPTION
- 로그인 창안에 하위 버튼의 위치와 명명을 변경 하였습니다.
- 해당 버튼들을 각각 손님으로 입장(게스트), 회원가입, 비밀번호 찾기, 로그인 으로 변경하였습니다.

<img width="854" height="548" alt="스크린샷 2025-09-27 10 07 32" src="https://github.com/user-attachments/assets/3754a20f-53a3-4f42-8f9d-435723eb43ab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - ‘손님으로 입장’ 버튼을 통해 비회원(게스트) 로그인 지원. 회원가입 없이 바로 서비스 체험 가능.
- 변경
  - 로그인 화면 버튼 라벨과 동작 재구성: 첫 번째는 게스트 입장, 두 번째는 회원가입 진입, 세 번째는 로그인 시도로 통일. 전반적 흐름 명확화.
- 기타
  - UI 텍스트 정제 및 주석 정렬 등 사소한 정리(기능 영향 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->